### PR TITLE
Requiring PHPUnit/Autload throws error when outside bootstrap is used

### DIFF
--- a/lib/VPU.php
+++ b/lib/VPU.php
@@ -35,8 +35,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-require 'PHPUnit/Autoload.php';
-require 'PHPUnit/Util/Log/JSON.php';
+require_once 'PHPUnit/Autoload.php';
+require_once 'PHPUnit/Util/Log/JSON.php';
 
 class VPU {
 


### PR DESCRIPTION
The straight "require" of the PHPUnit/Autoload.php was causing an error to be thrown when using a CIUnit bootstrap file.  That file require_once'ed Autoload.php already, so require'ing it again caused problems.
