### PR TITLE
The line breaks are replaced with a <br /> instead of an empty string

### DIFF
--- a/lib/VPU.php
+++ b/lib/VPU.php
@@ -597,7 +597,7 @@ class VPU {
         }
 
         $results = '[' . rtrim($results, ',') . ']';
-        $results = str_replace('\n', '', $results);
+        $results = str_replace('\n', '<br/>', $results);
         $results = str_replace('&quot;', '"', $results);
 
         $results = json_decode($results, true);


### PR DESCRIPTION
Before the fix, the debug info was printed in one long line.

Regards.
