### PR TITLE
[Fix] Windows Directory Separator

### DIFF
--- a/app/lib/VPU.php
+++ b/app/lib/VPU.php
@@ -396,6 +396,9 @@ class VPU {
 
             $ext = strtolower(pathinfo($test, PATHINFO_EXTENSION));
             if ( file_exists($test) && $ext == 'php' )  {
+                if (DIRECTORY_SEPARATOR == '\\') {
+                    $test = str_replace('/','\\',$test);
+                }
                 $collection[] = $test;
             }
         }


### PR DESCRIPTION
This fixes a bug where duplicate test classes were left (causing PHP errors) as 'RecursiveIteratorIterator` returns files with the correct DIRECTOR_SEPARATOR but the data passed in from the frontend always contains unix Directory Separators '/' 
