### PR TITLE
Allow multiple PHPUnit configuration files

### DIFF
--- a/app/controller/Home.php
+++ b/app/controller/Home.php
@@ -72,8 +72,17 @@ class Home extends \app\core\Controller {
 
         $notifications = array();
         if ( $request->data['use_xml'] ) {
-            $xml_config = \app\lib\Library::retrieve('xml_configuration_file');
-            if ( !$xml_config || !$xml_config = realpath($xml_config) ) {
+            if ( $xml_config = \app\lib\Library::retrieve('xml_configuration_file') ) {
+                if ( is_array($xml_config) ) {
+                    $config_id = array_search($request->data['use_xml'], $xml_config);
+                    $xml_config = ( false !== $config_id )
+                        ? realpath($xml_config[$config_id])
+                        : false;
+                } else {
+                    $xml_config = realpath($xml_config);
+                }
+            }
+            if ( !$xml_config ) {
                 $notifications[] = array(
                     'type'    => 'failed',
                     'title'   => 'No Valid XML Configuration File Found',

--- a/app/view/home/index.html
+++ b/app/view/home/index.html
@@ -104,7 +104,13 @@
                 </label>
                 <select id='use_xml' name='use_xml' class='test-options'>
                   <option value='0'>No</option>
-                  <option value='1' <?php if ( $use_xml ) echo "selected='selected'"; ?>>Yes</option>
+                  <?php if ( is_array($use_xml) ) {
+                            foreach ( $use_xml as $xml_path ) { ?>
+                                <option value='<?php echo $xml_path; ?>'><?php echo $xml_path; ?></option>
+                  <?php     }
+                        } else { ?>
+                    <option value='1' <?php if ( $use_xml ) echo "selected='selected'"; ?>>Yes</option>
+                  <?php } ?>
                 </select>
                 <p class='help-block'>
                   Note that setting this to "Yes" will cause VPU to ignore the tests selected above and use the tests specified in the XML file instead.


### PR DESCRIPTION
Add code in to allow multiple PHPUnit configuration files to be
specified in the bootstrap config array
