### PR TITLE
Add message to failed test for string comparisons that shows expected and actual Strings.

### DIFF
--- a/app/lib/PHPUnit_Util_Log_JSON_With_String_Comparison.php
+++ b/app/lib/PHPUnit_Util_Log_JSON_With_String_Comparison.php
@@ -8,7 +8,7 @@ if (!class_exists('PHPUnit_Util_Log_JSON_With_String_Comparison')) {
     {
         public function addFailure(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_AssertionFailedError $e, $time)
         {
-            if ( $e instanceof \PHPUnit_Framework_ExpectationFailedException ) {
+            if ( $e instanceof \PHPUnit_Framework_ExpectationFailedException && $e->getComparisonFailure() ) {
                 $new_message =  $e->getComparisonFailure()->toString() ;
                 $e2 = new \PHPUnit_Framework_ExpectationFailedException($new_message, $e->getComparisonFailure(), $e);
                 parent::addFailure($test, $e2, $time);

--- a/app/lib/PHPUnit_Util_Log_JSON_With_String_Comparison.php
+++ b/app/lib/PHPUnit_Util_Log_JSON_With_String_Comparison.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace app\lib;
+
+if (!class_exists('PHPUnit_Util_Log_JSON_With_String_Comparison')) {
+
+    class PHPUnit_Util_Log_JSON_With_String_Comparison extends \PHPUnit_Util_Log_JSON
+    {
+        public function addFailure(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_AssertionFailedError $e, $time)
+        {
+            if ( $e instanceof \PHPUnit_Framework_ExpectationFailedException ) {
+                $new_message =  $e->getComparisonFailure()->toString() ;
+                $e2 = new \PHPUnit_Framework_ExpectationFailedException($new_message, $e->getComparisonFailure(), $e);
+                parent::addFailure($test, $e2, $time);
+            } else {
+                parent::addFailure($test, $e, $time);
+            }
+        }
+    }
+
+}
+?>
+

--- a/app/lib/VPU.php
+++ b/app/lib/VPU.php
@@ -2,6 +2,8 @@
 
 namespace app\lib;
 
+include_once('PHPUnit_Util_Log_JSON_With_String_Comparison.php');
+
 class VPU {
 
    /**
@@ -428,7 +430,7 @@ class VPU {
         }
 
         $result = new \PHPUnit_Framework_TestResult();
-        $result->addListener(new \PHPUnit_Util_Log_JSON());
+        $result->addListener(new PHPUnit_Util_Log_JSON_With_String_Comparison());
 
         // We need to temporarily turn off html_errors to ensure correct
         // parsing of test debug output

--- a/app/test/StringCompareTest.php
+++ b/app/test/StringCompareTest.php
@@ -1,0 +1,19 @@
+<?php
+
+class StringCompareTest extends PHPUnit_Framework_TestCase {
+    public function test_this() {
+        $key = 'string';
+        $value = 'different string';
+        $this->assertEquals($key, $value, 'test_this() failed!');
+    }
+
+    public function test_this_too() {
+        $key = 'test';
+        $value = 'test';
+        print_r('foo { breaks: this } bar');
+        print_r('foo breaks: this { bar');
+        $this->assertEquals($key, $value, 'test_this_too() failed!');
+    }
+}
+
+?>


### PR DESCRIPTION
Example:
--- Expected +++ Actual @@ @@ -'string' +'different string'

![screen shot 2013-05-01 at 9 15 00 am](https://f.cloud.github.com/assets/1474660/449542/cf8729c8-b275-11e2-871a-efffa9b53d35.png)
