### PR TITLE
Change views to use protocol relative urls for loading of external resources

### DIFF
--- a/app/view/archives/index.html
+++ b/app/view/archives/index.html
@@ -16,7 +16,7 @@
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
   </head>
 
@@ -119,7 +119,7 @@
 
     </div>
 
-    <script src='http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js'></script>
+    <script src='//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js'></script>
     <script src='./js/jquery.sortElements.js'></script>
     <script>
       $(document).ready(function() {

--- a/app/view/graph/index.html
+++ b/app/view/graph/index.html
@@ -13,11 +13,11 @@
       }
     </style>
     <link href="./css/bootstrap-responsive.css" rel="stylesheet">
-    <link href='http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.19/themes/redmond/jquery-ui.css' rel='stylesheet'>
+    <link href='//ajax.googleapis.com/ajax/libs/jqueryui/1.8.19/themes/redmond/jquery-ui.css' rel='stylesheet'>
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
   </head>
 
@@ -93,10 +93,10 @@
 
     </div>
 
-    <script src='http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js'></script>
-    <script src='http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.19/jquery-ui.min.js'></script>
-    <script src='http://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.3.3/underscore-min.js'></script>
-    <script src='http://cdnjs.cloudflare.com/ajax/libs/highcharts/2.2.3/highcharts.js'></script>
+    <script src='//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js'></script>
+    <script src='//ajax.googleapis.com/ajax/libs/jqueryui/1.8.19/jquery-ui.min.js'></script>
+    <script src='//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.3.3/underscore-min.js'></script>
+    <script src='//cdnjs.cloudflare.com/ajax/libs/highcharts/2.2.3/highcharts.js'></script>
     <script src='./js/bootstrap-alert.js'></script>
 
     <script type='text/html' id='error'>

--- a/app/view/home/help.html
+++ b/app/view/home/help.html
@@ -16,7 +16,7 @@
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
   </head>
 

--- a/app/view/home/index.html
+++ b/app/view/home/index.html
@@ -16,7 +16,7 @@
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
   </head>
 
@@ -171,8 +171,8 @@
 
     </div>
 
-    <script src='http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js'></script>
-    <script src='http://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.3.3/underscore-min.js'></script>
+    <script src='//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js'></script>
+    <script src='//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.3.3/underscore-min.js'></script>
     <script src='./js/jqueryFileSelector.js'></script>
     <script src='./js/jquery.sortElements.js'></script>
     <script src='./js/bootstrap-alert.js'></script>


### PR DESCRIPTION
Currently VisualPHPUnit will fail to load when served over https. This commit fixes that issue by using protocol relative urls IE // instead of http:// or https://
