### PR TITLE
Replace the call to PHPUnit_TextUI_Command->run by shell_exec

### DIFF
--- a/app/lib/VPU.php
+++ b/app/lib/VPU.php
@@ -519,24 +519,16 @@ class VPU
     public function runWithXml($xml_config)
     {
         $this->checkXmlConfiguration($xml_config);
-        $command = new PHPUnit_TextUI_Command();
         
         // We need to temporarily turn off html_errors to ensure correct
         // parsing of test debug output
         $html_errors = ini_get('html_errors');
         ini_set('html_errors', 0);
-        
-        ob_start();
-        $command->run(array(
-            '--configuration',
-            $xml_config,
-            '--stderr'
-        ), false);
-        $results = ob_get_contents();
-        if (ob_get_length()) {
-            ob_end_clean();
-        }
-        
+
+        $vendor_path = Library::retrieve('composer_vendor_path');
+        $command = "$vendor_path/bin/phpunit --configuration $xml_config --stderr";
+        $results = shell_exec( $command." 2>&1" );
+
         ini_set('html_errors', $html_errors);
         
         $start = strpos($results, '{');

--- a/app/lib/VPU.php
+++ b/app/lib/VPU.php
@@ -14,7 +14,6 @@ namespace app\lib;
 use \RecursiveDirectoryIterator;
 use \RecursiveIteratorIterator;
 use \DomainException;
-use \PHPUnit_TextUI_Command;
 use \PHPUnit_Framework_TestResult;
 use \PHPUnit_Util_Log_JSON;
 use \PHPUnit_Framework_TestSuite;
@@ -527,7 +526,7 @@ class VPU
 
         $vendor_path = Library::retrieve('composer_vendor_path');
         $command = "$vendor_path/bin/phpunit --configuration $xml_config --stderr";
-        $results = shell_exec( $command." 2>&1" );
+        $results = shell_exec($command." 2>&1");
 
         ini_set('html_errors', $html_errors);
         


### PR DESCRIPTION
This patch fixes this bug : https://github.com/VisualPHPUnit/VisualPHPUnit/issues/131

The issue comes from the handling of the output buffer in PHPUnit_TextUI_Command->run and it, sadly, doesn't look as if it would be fixed soon : 
https://github.com/sebastianbergmann/phpunit/issues/1635

I'm not sure it's the best way to do that but it seems to be the most robust.