### PR TITLE
Fix running with PHPUnit XML Configuration File

### DIFF
--- a/app/config/bootstrap.php
+++ b/app/config/bootstrap.php
@@ -21,6 +21,8 @@ $config = array(
 
     // The directory where Composer vendor is located (the one that phpunit was required into)
     'composer_vendor_path' => $root . '/vendor',
+    // The directory where Composer bin is located (where phpunit command is located)
+    'composer_bin_path' => $root . '/bin',
 
     // The directories where the tests reside
     'test_directories' => array(

--- a/app/config/phpunit.xml
+++ b/app/config/phpunit.xml
@@ -4,7 +4,7 @@
 
   <testsuites>
     <testsuite>
-      <directory>/srv/http/vpu/app/test</directory>
+      <directory suffix=".php">../test</directory>
     </testsuite>
   </testsuites>
 

--- a/app/lib/VPU.php
+++ b/app/lib/VPU.php
@@ -524,14 +524,12 @@ class VPU
         $html_errors = ini_get('html_errors');
         ini_set('html_errors', 0);
 
-        $vendor_path = Library::retrieve('composer_vendor_path');
-        $command = "$vendor_path/bin/phpunit --configuration $xml_config --stderr";
-        $results = shell_exec($command." 2>&1");
+        $bin_path = Library::retrieve('composer_bin_path');
+        $command = "$bin_path/phpunit --configuration $xml_config --stderr";
+        $results = shell_exec($command);
 
         ini_set('html_errors', $html_errors);
-        
-        $start = strpos($results, '{');
-        $end = strrpos($results, '}');
-        return substr($results, $start, $end - $start + 1);
+
+        return $results;
     }
 }


### PR DESCRIPTION
The current `master` branch still does not work with PHPUnit XML Configuration File.
The results were all 0.

This PR fixes it. And I've got the results:

~~~
Suite Statistics
Failed (3/9)
Incomplete (2/9)
Skipped (1/9)
Succeeded (3/9)

Test Statistics
Failed (5/17)
Incomplete (2/17)
Skipped (1/17)
Succeeded (9/17)
~~~
