### PR TITLE
Running test returned error Serialization of 'Closure' is not allowed

### DIFF
--- a/backend/index.php
+++ b/backend/index.php
@@ -14,5 +14,16 @@
 require __DIR__ . '/../vendor/autoload.php';
 use Visualphpunit\Api\Application\Vpu;
 
-$app = new Vpu();
-$app->run();
+/**
+ * Prevent app to be added to the $GLOBALS
+ *
+ * @return void
+ */
+function run()
+{
+    $app = new Vpu();
+    $app->run();
+}
+
+run();
+


### PR DESCRIPTION
When running test I got the error ```Serialization of 'Closure' is not allowed```. This is caused by the ```$app``` declaration in the global scope in ```backend/index.php```. PHPUnit tries to serialise the ```$GLOBALS``` throwing this error. Moving it to a function prevents this.
See issue: #164 