### PR TITLE
Type Error: Cannot create property 'passedPercentage' on string 'nofiles'

### DIFF
--- a/app/scripts/controllers/main.js
+++ b/app/scripts/controllers/main.js
@@ -43,7 +43,7 @@ angular.module('VisualPHPUnit').controller('MainCtrl', function($scope, $http) {
             var responsePromise = $http(config);
             responsePromise.success(function(data) {
                 var result = data[0];
-                if (data !== 'nofiles') {
+                if (data != 'nofiles') {
                     Vpu.renderSuite("#result", result);
                 }
             });


### PR DESCRIPTION
when no tests are selected, the double equal is causing js error Type Error: Cannot create property 'passedPercentage' on string 'nofiles'

fixed by changing to single equal