### PR TITLE
Promise - Replace the deprecated $http.success by $http.then

### DIFF
--- a/app/scripts/controllers/archives.js
+++ b/app/scripts/controllers/archives.js
@@ -12,9 +12,9 @@ angular.module('VisualPHPUnit').controller('ArchivesCtrl',
                 url : Vpu.getBackend() + '/archives'
             };
             var responsePromise = $http(config);
-            responsePromise.success(function(data) {
+            responsePromise.then(function(response) {
                 $('#archives').treeview({
-                    data : data,
+                    data : response.data,
                     levels : 1,
                     showTags : false,
                     multiSelect : false,
@@ -31,9 +31,9 @@ angular.module('VisualPHPUnit').controller('ArchivesCtrl',
                             url : Vpu.getBackend() + '/suite/' + id
                         };
                         var responsePromise = $http(config);
-                        responsePromise.success(function(data) {
-                            if (data !== 'nosuite') {
-                                Vpu.renderSuite("#suite", data);
+                        responsePromise.then(function(response) {
+                            if (response.data !== 'nosuite') {
+                                Vpu.renderSuite("#suite", response.data);
                             }
                             Vpu.applyStatusFilter();
                         });

--- a/app/scripts/controllers/graph.js
+++ b/app/scripts/controllers/graph.js
@@ -70,9 +70,9 @@ angular.module('VisualPHPUnit').controller('GraphCtrl', function($scope, $http) 
                     url : Vpu.getBackend() +'/graph/' + timeframe + '/' + start + '/' + end
                 };
                 var responsePromise = $http(config);
-                responsePromise.success(function(data) {
+                responsePromise.then(function(response) {
 
-                    var forgraph = prepareData(data);
+                    var forgraph = prepareData(response.data);
 
                     var graphdata = {
                         labels : forgraph['label'],

--- a/app/scripts/controllers/main.js
+++ b/app/scripts/controllers/main.js
@@ -11,9 +11,9 @@ angular.module('VisualPHPUnit').controller('MainCtrl', function($scope, $http) {
         url : Vpu.getBackend() + '/tests'
     };
     var responsePromise = $http(config);
-    responsePromise.success(function(data) {
+    responsePromise.then(function(response) {
         $('#tree').treeview({
-            data : data,
+            data : response.data,
             levels : 1,
             showTags : true,
             multiSelect : true,
@@ -41,20 +41,19 @@ angular.module('VisualPHPUnit').controller('MainCtrl', function($scope, $http) {
                 data : request
             };
             var responsePromise = $http(config);
-            responsePromise.success(function(data) {
-                var result = data[0];
-                if (data != 'nofiles') {
+            responsePromise.then(function(response) {
+                var result = response.data[0];
+                if (response.data != 'nofiles') {
                     Vpu.renderSuite("#result", result);
                 }
             });
         });
 
+    },function(response) {
+        console.log('failur');
+        console.log(response.data);
     });
 
-    responsePromise.error(function(data) {
-        console.log('failur');
-        console.log(data);
-    });
 
     Vpu.addFilterEvents();
 });


### PR DESCRIPTION
$http.success() and error() are considered deprecated. They don't support 100% the promise. I have replace $http.success() and error() by $http.then()