### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/tests/Console/Application/VpuTest.php
+++ b/tests/Console/Application/VpuTest.php
@@ -2,8 +2,9 @@
 namespace Visualphpunit\Test\Application\Command;
 
 use Visualphpunit\Console\Application\Vpu;
+use PHPUnit\Framework\TestCase;
 
-class VpuTest extends \PHPUnit_Framework_TestCase
+class VpuTest extends TestCase
 {
 
     /**

--- a/tests/Console/Command/RunTest.php
+++ b/tests/Console/Command/RunTest.php
@@ -2,8 +2,9 @@
 namespace Visualphpunit\Test\Console\Command;
 
 use Visualphpunit\Console\Command\Run;
+use PHPUnit\Framework\TestCase;
 
-class RunTest extends \PHPUnit_Framework_TestCase
+class RunTest extends TestCase
 {
 
     /**
@@ -17,7 +18,7 @@ class RunTest extends \PHPUnit_Framework_TestCase
     public function correctInstantiation()
     {
         $command = new Run();
-        
+
         $this->assertInstanceOf('Visualphpunit\Console\Command\Run', $command);
     }
 }

--- a/tests/ExpectedFailureTest.php
+++ b/tests/ExpectedFailureTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace Visualphpunit\Test;
 
-class ExpectedFailureTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ExpectedFailureTest extends TestCase
 {
 
     /**
@@ -13,7 +15,7 @@ class ExpectedFailureTest extends \PHPUnit_Framework_TestCase
     {
         $this->markTestIncomplete('This test has not been implemented yet.');
     }
-    
+
     /**
      * This is purposely failing to demonstrated the output in VPU
      *
@@ -23,7 +25,7 @@ class ExpectedFailureTest extends \PHPUnit_Framework_TestCase
     {
         throw new \Exception('This test results in an error on purpose.');
     }
-    
+
     /**
      * This is purposely skipped to demonstrated the output in VPU
      *
@@ -35,7 +37,7 @@ class ExpectedFailureTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('The something_bogus extension is not available.');
         }
     }
-    
+
     /**
      * This is purposely failing to demonstrated the output in VPU
      *
@@ -47,7 +49,7 @@ class ExpectedFailureTest extends \PHPUnit_Framework_TestCase
         $actual   = 'actual';
         $this->assertEquals($expected, $actual);
     }
-    
+
     /**
      * This is purposely failing to demonstrated the output in VPU
      *


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).